### PR TITLE
Unpin R

### DIFF
--- a/nomad.yml
+++ b/nomad.yml
@@ -1,5 +1,5 @@
-# Let's pin things to a specific R version
-r_version: 3.4.2
+# Use whatever the current version of R is
+r_version: release
 
 # All platforms (this is the default)
 target: ALL
@@ -16,5 +16,5 @@ rtools: true
 
 # label the release
 name: deployer
-version: "1.0"
+version: "1.1"
 


### PR DESCRIPTION
Fixes https://github.com/reconhub/nomad/issues/12

IMO it's probably preferable to pin to a specific version but that was obviously surprising behaviour.  Alternatively we might just document this better in the README?