### PR TITLE
add function to add a single package from source

### DIFF
--- a/inst/README.Rmd
+++ b/inst/README.Rmd
@@ -97,6 +97,10 @@ sudo make install
 To install packages using the *RECON deployer* instead of internet, you need to:
 
 1. Double-click on `deployer.Rproj` to open RStudio to this directory.
+   (If you do not have RStudio installed, then please make sure you set your
+    working directory to the deployer directory. Open R, copy and past this code,
+   and select the `deployer.Rproj` file from the popup browser: 
+   `setwd(dirname(file.choose()))`)
 1. Activate the deployer by sourcing the script `activate.R`, located at the
    root of the deployer (use `source("activate.R")`)
 2. install packages as usual (the deployer replaces your internet connection)
@@ -143,6 +147,23 @@ instance, to install `reportfactory`, use:
 ```{r eval = FALSE}
 install.packages("reportfactory")
 ```
+
+## Updating a single package/fixing bugs
+
+If you are actively maintaining a deployer in the field, it's not feasible to
+create a brand-new deployerfor every small change to one package you need to
+do. The script `update_deployer.R` has a function called `deploy_package()`
+that will build a deployer package from source and update the repositories in
+the deployer, allowing updates to take place. To use this, simply do the
+following
+
+```{r eval = FALSE}
+source("update_deployer.R")
+deploy_package("../incidence") # build new version of the incidence package,
+                               # assuming the source code is in the directory
+                               # above the deployer. 
+```
+
 
 <br>
 <br>

--- a/inst/update_deployer.R
+++ b/inst/update_deployer.R
@@ -1,14 +1,14 @@
 #' Update a package in a deployer from the source code
 #'
 #' @param pkg the path to a package source
-#' @param repo path to a drat repo. Defaults to both the current and 'drat' repo 
+#' @param repo path to a drat repo. Defaults to the current  repo 
 #' @param internet a future parameter to update packages from internet if it is
 #'   available.
 #' @examples
 #'
 #' deploy_package("../linelist") # update the linelist package, assuming its
 #'   source lives one directory upstream of this deployer
-deploy_package <- function(pkg = NULL, repo = c(here::here(), here::here("drat")), internet = FALSE) {
+deploy_package <- function(pkg = NULL, repo = ".", internet = FALSE) {
   if (is.null(pkg)) {
     msg <- paste(
       "Please supply a path to a package source"
@@ -16,26 +16,16 @@ deploy_package <- function(pkg = NULL, repo = c(here::here(), here::here("drat")
     stop(msg)
   }
   stopifnot(file.exists(pkg))
+  stopifnot(file.exists(file.path(repo, 'src', 'contrib')))
   
   vers <- read.dcf(file.path(pkg, "DESCRIPTION"))[, "Version"]
   message("Building source package ...")
-  src <- devtools::build(pkg, path = here::here(), binary = FALSE)
-  message(sprintf("Building binary package for %s", R.version$os))
-  bin <- devtools::build(pkg, path = here::here(), binary = TRUE)
+  src <- devtools::build(pkg, path = repo, binary = FALSE)
   
 
-  for (i in repo) {
-    message(sprintf("Adding source and binary to %s", i))
-    drat::insertPackage(src, 
-                        action = "archive", 
-                        repodir = i)
-
-    drat::insertPackage(bin, 
-                        action = "archive", 
-                        repodir = i)
-  }
+  message(sprintf("Adding package and to %s", repo))
+  drat::insertPackage(src, action = "archive", repodir = repo) 
   
   unlink(src)
-  unlink(bin)
   return(NULL)
 }

--- a/inst/update_deployer.R
+++ b/inst/update_deployer.R
@@ -25,7 +25,7 @@ deploy_package <- function(pkg = NULL, repo = c(here::here(), here::here("drat")
   
 
   for (i in repo) {
-    message(sprintf("Adding source and binary to %", i))
+    message(sprintf("Adding source and binary to %s", i))
     drat::insertPackage(src, 
                         action = "archive", 
                         repodir = i)

--- a/inst/update_deployer.R
+++ b/inst/update_deployer.R
@@ -1,0 +1,41 @@
+#' Update a package in a deployer from the source code
+#'
+#' @param pkg the path to a package source
+#' @param repo path to a drat repo. Defaults to both the current and 'drat' repo 
+#' @param internet a future parameter to update packages from internet if it is
+#'   available.
+#' @examples
+#'
+#' deploy_package("../linelist") # update the linelist package, assuming its
+#'   source lives one directory upstream of this deployer
+deploy_package <- function(pkg = NULL, repo = c(here::here(), here::here("drat")), internet = FALSE) {
+  if (is.null(pkg)) {
+    msg <- paste(
+      "Please supply a path to a package source"
+    )
+    stop(msg)
+  }
+  stopifnot(file.exists(pkg))
+  
+  vers <- read.dcf(file.path(pkg, "DESCRIPTION"))[, "Version"]
+  message("Building source package ...")
+  src <- devtools::build(pkg, path = here::here(), binary = FALSE)
+  message(sprintf("Building binary package for %s", R.version$os))
+  bin <- devtools::build(pkg, path = here::here(), binary = TRUE)
+  
+
+  for (i in repo) {
+    message(sprintf("Adding source and binary to %", i))
+    drat::insertPackage(src, 
+                        action = "archive", 
+                        repodir = i)
+
+    drat::insertPackage(bin, 
+                        action = "archive", 
+                        repodir = i)
+  }
+  
+  unlink(src)
+  unlink(bin)
+  return(NULL)
+}


### PR DESCRIPTION
Ideally, this will be run from the deployer directory, with the user pointing their way to the package.

This addresses #18

Caveats:

- updating a package in the top-level directory takes time
- this will build both binary and source versions of the packages