### PR TITLE
Update packages with binary either from CRAN or local file

### DIFF
--- a/inst/update_deployer.R
+++ b/inst/update_deployer.R
@@ -8,24 +8,66 @@
 #'
 #' deploy_package("../linelist") # update the linelist package, assuming its
 #'   source lives one directory upstream of this deployer
-deploy_package <- function(pkg = NULL, repo = ".", internet = FALSE) {
+#'
+#' # download and insert the binary and windows packages for prettydoc
+#' deploy_package("prettydoc", internet = TRUE, windows = TRUE)
+deploy_package <- function(pkg = NULL, repo = ".", internet = FALSE, windows = TRUE, macos = FALSE, el.capitan = macos) {
   if (is.null(pkg)) {
     msg <- paste(
-      "Please supply a path to a package source"
+                 "Please supply a path to a package source"
     )
     stop(msg)
   }
-  stopifnot(file.exists(pkg))
+  src <- win <- mac <- elc <- NULL
   stopifnot(file.exists(file.path(repo, 'src', 'contrib')))
-  
-  vers <- read.dcf(file.path(pkg, "DESCRIPTION"))[, "Version"]
-  message("Building source package ...")
-  src <- devtools::build(pkg, path = repo, binary = FALSE)
-  
+  ext <- tools::file_ext(pkg)
+  tmp <- tempdir()
+  #
+  # The package is a folder on the user's directory
+  if (ext == "" && dir.exists(pkg)) {
+    vers <- read.dcf(file.path(pkg, "DESCRIPTION"))[, "Version"]
+    message("Building source package ...")
+    pkg <- devtools::build(pkg, path = tmp, binary = FALSE)
+  } else if (ext == "" && internet) { # The package is one the user wants to download
+    message("Downloading the source package from CRAN ...")
+    try(src <- download.packages(pkg, type = "source", destdir = tmp)[2])
+    if (windows) { 
+      try(win <- download.packages(pkg, type = "win.binary", destdir = tmp)[2])
+    }
+    if (macos) {
+      try(mac <- download.packages(pkg, type = "mac.binary", destdir = tmp)[2])
+    }
+    if (el.capitan) {
+      try(elc <- download.packages(pkg, type = "mac.binary.el-capitan", destdir = tmp)[2])
+    }
+  } else if (file.exits(pkg)) { # The file is a binary
+    src <- pkg
+  } else {
+    stop(sprintf("%s doesn't appear to be a file or folder and I can't download it.", pkg))
+  }
 
-  message(sprintf("Adding package and to %s", repo))
+  # adding source package ------------------------------------------------------
+  message(sprintf("Adding source package and to %s", repo))
   drat::insertPackage(src, action = "archive", repodir = repo) 
-  
-  unlink(src)
+
+  # adding windows package -----------------------------------------------------
+  if (!is.null(win)) {
+    message(sprintf("Adding windows package and to %s", repo))
+    try(drat::insertPackage(win, action = "archive", repodir = repo))
+  }
+
+  # adding macos package -----------------------------------------------------
+  if (!is.null(mac)) {
+    message(sprintf("Adding macos package and to %s", repo))
+    try(drat::insertPackage(mac, action = "archive", repodir = repo))
+  }
+
+  # adding macos.el-capitan package -----------------------------------------------------
+  if (!is.null(mac)) {
+    message(sprintf("Adding macos el-capitan package and to %s", repo))
+    try(drat::insertPackage(elc, action = "archive", repodir = repo))
+  }
+  # ----------------------------------------------------------------------------
+
   return(NULL)
 }

--- a/inst/update_deployer.R
+++ b/inst/update_deployer.R
@@ -40,7 +40,7 @@ deploy_package <- function(pkg = NULL, repo = ".", internet = FALSE, windows = T
     if (el.capitan) {
       try(elc <- download.packages(pkg, type = "mac.binary.el-capitan", destdir = tmp)[2])
     }
-  } else if (file.exits(pkg)) { # The file is a binary
+  } else if (file.exists(pkg)) { # The file is a binary
     src <- pkg
   } else {
     stop(sprintf("%s doesn't appear to be a file or folder and I can't download it.", pkg))


### PR DESCRIPTION
This adds the option to install binary/tarball packages to the repo with the option to download from CRAN. The limitation it has right now is the fact that it does nothing to check for dependencies.

This employs a bunch of try statements so that it will attempt to blow through functions that may return errors to get to the end of the process. 

The user must specify `internet = TRUE` if they want to download from the internet, otherwise they
get an error:

```r
deploy_package("prettydoc")
## Error in deploy_package("prettydoc") :
##  prettydoc doesn't appear to be a file or folder and I can't download it.
```

If they specify `internet = TRUE`, then it will download the source package by default and the `windows, macos, el.capitan` options allow downloading specific binaries. By default, `windows = TRUE`.

```r
deploy_package("prettydoc", internet = TRUE)
## Downloading the source package from CRAN ...
## trying URL 'https://cran.rstudio.com/src/contrib/prettydoc_0.2.1.tar.gz'
## Content type 'application/x-gzip' length 520733 bytes (508 KB)
## ==================================================
## downloaded 508 KB

## trying URL 'https://cran.rstudio.com/bin/windows/contrib/3.5/prettydoc_0.2.1.zip'
## Content type 'application/zip' length 566187 bytes (552 KB)
## ==================================================
## downloaded 552 KB

## Adding source package and to .
## Adding windows package and to .
```