### PR TITLE
Add packages and helper scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .Rproj.user
 *~
+*.swp
 .Rhistory

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The RECON Deployer is an application of `nomad`, a R package for creating
 portable R environments. You first need to install this package, which also depends on `provisionr`:
 
 ```r
-devtools::install_github("mrc-ide/provisionr", upgrade = FALSE)
-devtools::install_github("reconhub/nomad", upgrade = FALSE)
+remotes::install_github("mrc-ide/provisionr", upgrade = FALSE)
+remotes::install_github("reconhub/nomad", upgrade = FALSE)
 ```
 
 To create a deployer in a given directory named `deployer_[date]`, type:

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ The *RECON deployer* project focusses on distributing an R environment for outbr
 * scripts to permit seemless installation of the local CRAN and github packages 
 
 
-## Using a *deployer* [#using]
+## Using a *deployer*
 
 You can find versioned releases of deployers at 
 https://github.com/reconhub/deployer/releases that detail how the deployer was
 built and how to download/decompress it. If you want to build one from scratch,
-see [Building a new deployer][building]
+see Building a new deployer
 
 The *RECON deployer* is meant to be copied on a USB stick, although strictly
 speaking it is medium-agnostic. To use the *deployer*, go to the folder where it
@@ -34,9 +34,9 @@ is stored, open the file called `README.html`, and follow the instructions
 provided there.
 
 
-## Building a new *deployer* {#building}
+## Building a new *deployer*
 
-To build/generate a new *deployer*, you can use the R script [`generate_deployer.R`]:
+To build/generate a new *deployer*, you can use the R script [`generate_deployer.R`](./generate_deployer.R):
 
 ```
 cd ..
@@ -98,9 +98,9 @@ nomad::build("reconhub/deployer", out_dir)
 ```
 
 
-## Adding or updating packages {#updating}
+## Adding or updating packages 
 
-If you need to add or update an R package, you can use the [`add_packages.R`]
+If you need to add or update an R package, you can use the [`add_packages.R`](./add_packages.R)
 script with the names of the CRAN packages to use.
 
 ```
@@ -108,4 +108,4 @@ Rscript add_packages.R officer kableExtra
 ```
 
 If you have non-cran packages, then be sure to add the github repositories to
-[`package_sources.txt`].
+[`package_sources.txt`](./package_sources.txt).

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ The *RECON deployer* project focusses on distributing an R environment for outbr
 The RECON Deployer is an application of `nomad`, a R package for creating
 portable R environments. You first need to install this package, which also depends on `provisionr`:
 
-```
+```r
 devtools::install_github("mrc-ide/provisionr", upgrade = FALSE)
 devtools::install_github("reconhub/nomad", upgrade = FALSE)
 ```
 
 To create a deployer in a given directory named `deployer_[date]`, type:
 
-```
+```r
 out_dir <- paste("deployer", gsub("-", "_", Sys.Date()), sep = "_")
 nomad::build("reconhub/deployer", out_dir)
 ```

--- a/README.md
+++ b/README.md
@@ -21,8 +21,66 @@ The *RECON deployer* project focusses on distributing an R environment for outbr
 * scripts to permit seemless installation of the local CRAN and github packages 
 
 
+## Using a *deployer* [#using]
 
-## Building a new *deployer*
+You can find versioned releases of deployers at 
+https://github.com/reconhub/deployer/releases that detail how the deployer was
+built and how to download/decompress it. If you want to build one from scratch,
+see [Building a new deployer][building]
+
+The *RECON deployer* is meant to be copied on a USB stick, although strictly
+speaking it is medium-agnostic. To use the *deployer*, go to the folder where it
+is stored, open the file called `README.html`, and follow the instructions
+provided there.
+
+
+## Building a new *deployer* {#building}
+
+To build/generate a new *deployer*, you can use the R script [`generate_deployer.R`]:
+
+```
+cd ..
+Rscript reconhub--deployer/generate_deployer.R
+```
+
+### Details
+
+The RECON Deployer is an application of `nomad`, a R package for creating
+portable R environments. This script will do the following:
+
+1. attempt to upgrade [provisioner](https://github.com/mrc-ide/provisionr) and 
+   [nomad](https://github.com/reconhub/nomad)
+2. generate the deployer
+3. split the deployer into 4 compressed files with md5sums that can be [uploaded
+   to github for release](https://github.com/reconhub/deployer/releases/new )
+
+The files you end up with are:
+
+| File name          | Description                                    |
+|--------------------|------------------------------------------------|
+|`<name>/`           | Source Directory for the deployer              |
+|`<name>_md5sums.txt`| summary of the above files                     |
+|`<name>_release.md` | release page to be placed on github            |
+|                    |                                                |
+|`<name>_base.tar`   | source packages, cheat sheets, and instructions|
+|`<name>_extra.tar`  | binaries for R, git, Rtools, and RStudio       |
+|`<name>_macosx.tar` | binary packages built for macos                |
+|`<name>_windows.tar`| binary packages built for windows              |
+
+> Note: These will likely be over 1GB each, so make sure you have a strong
+> internet connection when uploading these to github.
+
+Once downloaded from the github release page, the users can decompress the files
+via R:
+
+```r
+untar('<name>_base.tar')
+untar('<name>_extra.tar')
+untar('<name>_macosx.tar')
+untar('<name>_windows.tar')
+```
+
+### Generating the deployer manually
 
 The RECON Deployer is an application of `nomad`, a R package for creating
 portable R environments. You first need to install this package, which also depends on `provisionr`:
@@ -40,12 +98,14 @@ nomad::build("reconhub/deployer", out_dir)
 ```
 
 
+## Adding or updating packages {#updating}
 
-## Using a *deployer*
+If you need to add or update an R package, you can use the [`add_packages.R`]
+script with the names of the CRAN packages to use.
 
-The *RECON deployer* is meant to be copied on a USB stick, although strictly
-speaking it is medium-agnostic. To use the *deployer*, go to the folder where it
-is stored, open the file called `README.html`, and follow the instructions
-provided there.
+```
+Rscript add_packages.R officer kableExtra
+```
 
-
+If you have non-cran packages, then be sure to add the github repositories to
+[`package_sources.txt`].

--- a/add_packages.R
+++ b/add_packages.R
@@ -7,5 +7,19 @@ imsg <- "Usage: Rscript add_packages.R [...]
 "
 args <- commandArgs(trailingOnly = TRUE)
 if (is.na(args[1])) stop(imsg)
-pkglist <- readLines("package_list.txt")
-cat(sort(c(args, pkglist)), sep = "\n", file = "package_list.txt")
+punct <- grepl("[[:punct:]]", args)
+if (any(punct)) {
+  pkgs <- paste(args[punct], collapse = "\n")
+  message(sprintf("The following packages may need to be added to package_sources.txt:\n%s", pkgs)) 
+  args <- args[!punct]
+}
+
+pkglist  <- readLines("package_list.txt")
+pkgs     <- unique(sort(c(args, pkglist)))
+new_pkgs <- setdiff(pkgs, pkglist)
+
+message(paste("new package added:", new_pkgs, collapse = "\n"))
+
+cat(pkgs, sep = "\n", file = "package_list.txt")
+
+

--- a/add_packages.R
+++ b/add_packages.R
@@ -7,7 +7,7 @@ imsg <- "Usage: Rscript add_packages.R [...]
 "
 args <- commandArgs(trailingOnly = TRUE)
 if (is.na(args[1])) stop(imsg)
-punct <- grepl("[[:punct:]]", args)
+punct <- grepl("[^a-zA-Z0-9._]", args)
 if (any(punct)) {
   pkgs <- paste(args[punct], collapse = "\n")
   message(sprintf("The following packages may need to be added to package_sources.txt:\n%s", pkgs)) 

--- a/add_packages.R
+++ b/add_packages.R
@@ -1,0 +1,11 @@
+imsg <- "Usage: Rscript add_packages.R [...]
+        Arguments:
+            [...] a list of R packages to add to package_list.txt, separated by
+                  whitespace
+        Examples:
+        Rscript zkamvar.R fuzzyjoin kableExtra
+"
+args <- commandArgs(trailingOnly = TRUE)
+if (is.na(args[1])) stop(imsg)
+pkglist <- readLines("package_list.txt")
+cat(sort(c(args, pkglist)), sep = "\n", file = "package_list.txt")

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -68,6 +68,12 @@ message("Creating deployer...")
 
 nomad::build("reconhub/deployer", out_dir)
 
+# Generating README.html -------------------------------------------------------
+
+message("Generating deployer README...")
+
+rmarkdown::render(file.path(out_dir, "README.Rmd"))
+
 # Compress deployers -----------------------------------------------------------
 
 message("Compressing the deployers...")

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -54,11 +54,11 @@ tar(sprintf("%s_macosx.tar", out_dir), file.path(out_dir, "bin/macosx"),
     tar = sys_tar)
 
 # calculate and print md5sums
-the_tars  <- tools::md5sum(dir(pattern = "\\.tar$"))
+the_tars  <- tools::md5sum(dir(pattern = sprintf("^%s_(base|windows|macosx|extra)\\.tar$", out_dir)))
 print.tar <- function(x, ...) cat(paste0(x, '  ', names(x)), sep = "\n", ...)
 class(the_tars) <- "tar"
 the_tars
-print.tar(the_tars, file = sprintf("%s_md5sum.txt", out_dir)
+print.tar(the_tars, file = sprintf("%s_md5sum.txt", out_dir))
 
 
 

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -30,12 +30,30 @@ Usage: Rscript generate_deployer.R <name>
                This defaults to deployer_yyyy_mm_dd
 
 "
+
 args <- commandArgs(trailingOnly = TRUE)
 
 out_dir <- if (is.na(args[1])) sprintf("deployer_%s", gsub("-", "_", Sys.Date())) else args[1]
 
+# Updating packages ------------------------------------------------------------
+
+message("Updating provisionr and nomad...")
+
+if (!require("remotes")) {
+  install.packages("remotes")
+  library("remotes")
+}
+
+remotes::install_github("mrc-ide/provisionr", upgrade = FALSE)
+remotes::install_github("reconhub/nomad", upgrade = FALSE)
+
+# Deployer creation ------------------------------------------------------------
+
 message("Creating deployer...")
+
 nomad::build("reconhub/deployer", out_dir)
+
+# Compress deployers -----------------------------------------------------------
 
 message("Compressing the deployers...")
 
@@ -53,12 +71,87 @@ tar(sprintf("%s_macosx.tar", out_dir), file.path(out_dir, "bin/macosx"),
     extra_flags = "-v",
     tar = sys_tar)
 
-# calculate and print md5sums
+# Calculate md5 sums -----------------------------------------------------------
+
+message("Calculating md5 sums and writing %s_md5sum.txt ...", out_dir)
+
 the_tars  <- tools::md5sum(dir(pattern = sprintf("^%s_(base|windows|macosx|extra)\\.tar$", out_dir)))
 print.tar <- function(x, ...) cat(paste0(x, '  ', names(x)), sep = "\n", ...)
 class(the_tars) <- "tar"
 the_tars
 print.tar(the_tars, file = sprintf("%s_md5sum.txt", out_dir))
 
+# Creating release markdown document -------------------------------------------
 
+message("Creating %s_release.md...", out_dir)
+
+cat("
+
+   Produced by <GITHUB_NAME> via:
+
+```sh
+Rscript generate_deployer.R
+```
+
+## Installation
+
+Download the *.tar files in this release.
+
+Expected MD5 hash:
+
+```", 
+
+paste0(the_tars, '  ', names(the_tars)),
+
+"```
+
+Please confirm to avoid issues with corrupted downloads. You can do this with
+
+```r",
+
+sprintf("md5file <- '%s_md5sum.txt'", out_dir),
+
+"inlines <- readLines(md5file)
+xx <- sub(\"^([0-9a-fA-F]*)(.*)\", \"\\\\1\", inlines)
+nmxx <- names(xx) <- sub(\"^[0-9a-fA-F]* [ |*](.*)\", \"\\\\1\", inlines)
+print.tar <- function(x, ...) cat(paste0(x, '  ', names(x)), sep = '\\n', ...)",
+
+sprintf("the_tars  <- tools::md5sum(dir(pattern = '^%s_(base|windows|macosx|extra)\\\\.tar$'))", out_dir),
+
+"
+class(the_tars) <- 'tar'
+class(xx) <- 'tar'
+
+the_tars
+xx
+
+identical(xx, the_tars)
+```
+
+(this will take several seconds to run)
+
+To put back together, download these files and then run:
+
+```r",
+
+sprintf("untar('deployer_%s_base.tar')", out_dir),
+sprintf("untar('deployer_%s_windows.tar')", out_dir),
+sprintf("untar('deployer_%s_macosx.tar')", out_dir),
+sprintf("untar('deployer_%s_extra.tar')", out_dir),
+
+"``` 
+    
+", file = sprintf("%s_release.md", out_dir), sep = "\n")
+
+
+cat("
+
+    Please upload the tar files and md5sums to the deployer github release
+    page:
+
+    https://github.com/reconhub/deployer/releases/new
+
+    Make sure you add the release notes and tag yourself in the release.
+
+")
 

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -72,7 +72,8 @@ nomad::build("reconhub/deployer", out_dir)
 
 message("Generating deployer README...")
 
-rmarkdown::render(file.path(out_dir, "README.Rmd"))
+# Using try here so that it will continue, even if things fail
+try(rmarkdown::render(file.path(out_dir, "README.Rmd")))
 
 # Compress deployers -----------------------------------------------------------
 

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -15,6 +15,8 @@ The files you end up with are:
 <name>_extra.tar binaries for R, git, Rtools, and RStudio
 <name>_macosx.tar binary packages built for macos
 <name>_windows.tar binary packages built for windows
+<name>_md5sums.txt summary of the above files
+<name>_release.md release page to be placed on github
 
 Once downloaded, these can be decompressed via R:
 

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -1,0 +1,64 @@
+msg <- "
+
+Generate a RECON deployer to go.
+
+This script will do the following:
+
+1. attempt to upgrade provisioner and nomad
+2. generate the deployer
+3. split the deployer into 4 compressed files with md5sums that can be uploaded
+   to github for release
+
+The files you end up with are:
+
+<name>_base.tar source packages, cheat sheets, and instructions
+<name>_extra.tar binaries for R, git, Rtools, and RStudio
+<name>_macosx.tar binary packages built for macos
+<name>_windows.tar binary packages built for windows
+
+Once downloaded, these can be decompressed via R:
+
+untar('<name>_base.tar')
+untar('<name>_extra.tar')
+untar('<name>_macosx.tar')
+untar('<name>_windows.tar')
+
+Usage: Rscript generate_deployer.R <name>
+
+        Arguments:
+        <name> the name of the new directory in which to create the deployer.
+               This defaults to deployer_yyyy_mm_dd
+
+"
+args <- commandArgs(trailingOnly = TRUE)
+
+out_dir <- if (is.na(args[1])) sprintf("deployer_%s", gsub("-", "_", Sys.Date())) else args[1]
+
+message("Creating deployer...")
+nomad::build("reconhub/deployer", out_dir)
+
+message("Compressing the deployers...")
+
+sys_tar <- Sys.which("tar")
+tar(sprintf("%s_extra.tar", out_dir), file.path(out_dir, "extra"),
+    extra_flags = "-v",
+    tar = sys_tar)
+tar(sprintf("%s_base.tar", out_dir), out_dir,
+    extra_flags = sprintf("-v --exclude=%s/bin --exclude=%s/extra", out_dir),
+    tar = sys_tar)
+tar(sprintf("%s_windows.tar", out_dir), file.path(out_dir, "bin/windows"),
+    extra_flags = "-v",
+    tar = sys_tar)
+tar(sprintf("%s_macosx.tar", out_dir), file.path(out_dir, "bin/macosx"),
+    extra_flags = "-v",
+    tar = sys_tar)
+
+# calculate and print md5sums
+the_tars  <- tools::md5sum(dir(pattern = "\\.tar$"))
+print.tar <- function(x, ...) cat(paste0(x, '  ', names(x)), sep = "\n", ...)
+class(the_tars) <- "tar"
+the_tars
+print.tar(the_tars, file = sprintf("%s_md5sum.txt", out_dir)
+
+
+

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -11,31 +11,44 @@ This script will do the following:
 
 The files you end up with are:
 
-<name>_base.tar source packages, cheat sheets, and instructions
-<name>_extra.tar binaries for R, git, Rtools, and RStudio
-<name>_macosx.tar binary packages built for macos
-<name>_windows.tar binary packages built for windows
-<name>_md5sums.txt summary of the above files
-<name>_release.md release page to be placed on github
+| File name          | Description                                    |
+|--------------------|------------------------------------------------|
+|`<name>/`           | Source Directory for the deployer              |
+|`<name>_base.tar`   | source packages, cheat sheets, and instructions|
+|`<name>_extra.tar`  | binaries for R, git, Rtools, and RStudio       |
+|`<name>_macosx.tar` | binary packages built for macos                |
+|`<name>_windows.tar`| binary packages built for windows              |
+|`<name>_md5sums.txt`| summary of the above files                     |
+|`<name>_release.md` | release page to be placed on github            |
 
 Once downloaded, these can be decompressed via R:
 
+```r
 untar('<name>_base.tar')
 untar('<name>_extra.tar')
 untar('<name>_macosx.tar')
 untar('<name>_windows.tar')
+```
 
-Usage: Rscript generate_deployer.R <name>
+Usage: Rscript generate_deployer.R [-h|--help] <name>
 
         Arguments:
+        -h,--help print this message and exit
         <name> the name of the new directory in which to create the deployer.
                This defaults to deployer_yyyy_mm_dd
+
 
 "
 
 args <- commandArgs(trailingOnly = TRUE)
 
-out_dir <- if (is.na(args[1])) sprintf("deployer_%s", gsub("-", "_", Sys.Date())) else args[1]
+out_dir <- if (is.na(args[1])) {
+  sprintf("deployer_%s", gsub("-", "_", Sys.Date())) 
+} else if (args[1] == "-h" || args[1] == "--help") { 
+  stop(msg)
+} else { 
+  args[1] 
+}
 
 # Updating packages ------------------------------------------------------------
 

--- a/generate_deployer.R
+++ b/generate_deployer.R
@@ -44,7 +44,7 @@ tar(sprintf("%s_extra.tar", out_dir), file.path(out_dir, "extra"),
     extra_flags = "-v",
     tar = sys_tar)
 tar(sprintf("%s_base.tar", out_dir), out_dir,
-    extra_flags = sprintf("-v --exclude=%s/bin --exclude=%s/extra", out_dir),
+    extra_flags = sprintf("-v --exclude=%s/bin --exclude=%s/extra", out_dir, out_dir),
     tar = sys_tar)
 tar(sprintf("%s_windows.tar", out_dir), file.path(out_dir, "bin/windows"),
     extra_flags = "-v",

--- a/inst/README.Rmd
+++ b/inst/README.Rmd
@@ -22,6 +22,8 @@ unless you know what you are doing.**
 
 # About this deployer
 
+This deployer was generated on `r Sys.Date()`
+
 This is the *RECON deployer* version 03.18 (indicating the release date: March
 2018), which is the first stable version we distributed for deployment to the
 field, or in conditions where data analysis is done without a reliable internet
@@ -31,7 +33,7 @@ We do our best to make things work - for real! But if you think you have
 detected a potential bug, have requests, suggestions or questions, please post
 an issue on:
 
-[https://github.com/reconhub/deployer/issues](https://github.com/reconhub/deployer/issues)
+https://github.com/reconhub/deployer/issues
 
 
 # Using the *RECON deployer*
@@ -42,10 +44,10 @@ an issue on:
 
 Go to the `extra` folder, and install, in this order:
 
-1. Git (`Git-2.19.0-64-bit.exe`)
-2. Rtools (`Rtools34.exe`)
-3. R (`R-3.5.1-win.exe`)
-4. RStudio (`RStudio-1.1.456.exe`)
+1. Git (`r dir("./extra", pattern = "Git")`)
+2. Rtools (`r dir("./extra", pattern = "ools")`)
+3. R (`r dir("./extra", pattern = "R-.*.exe")`)
+4. RStudio (`r dir("./extra", pattern = "RStudio-.*.exe")`)
 
 
 ### MacOS
@@ -54,9 +56,9 @@ It is assumed that command line tools and git are already installed on the
 system, but we provide both R and RStudio as binaries:
 
 
-- `R-3.5.1.pkg`: R installer for MacOS. Install by double-clicking and following
+- `r dir("./extra", pattern = "R-.*.pkg")`: R installer for MacOS. Install by double-clicking and following
   the instructions.
-- `RStudio-1.1.456.dmg`: Rstudio for MacOS systems, installed as usual MacOS
+- `r dir("./extra", pattern = "RStudio-.*.dmg")`: Rstudio for MacOS systems, installed as usual MacOS
   apps by dragging the application to the `Applications` folder.
 
 
@@ -65,24 +67,25 @@ system, but we provide both R and RStudio as binaries:
 It is assumed that the toolchain for package development is
 already installed on the system, but we provide:
 
-- `rstudio-1.1.456-amd64.deb`: Rstudio for Linux debian-based systems (including
-  Ubuntu); can by installed by typing `sudo dpkg -i rstudio-1.1.456-amd64.deb`
+- `r dir("./extra", pattern = "rstudio-.*-amd64.deb")`: Rstudio for Linux debian-based systems (including
+  Ubuntu); can by installed by typing `r paste("sudo dpkg -i", dir("./extra", pattern = "rstudio-.*-amd64.deb"))`
 
-- `rstudio-1.1.456-x86_64.rpm`: Rstudio for Linux redhat based systems; can by
-  installed by typing `sudo rpm -i rstudio-1.1.456-x86_64.rpm`
+- `r dir("./extra", pattern = "rstudio-.*-x86_64.rpm")`: Rstudio for Linux redhat based systems; can by
+  installed by typing `r paste("sudo rpm -i", dir("./extra", pattern = "rstudio-.*-x86_64.rpm"))`
 
 To install R, see the next section on installing R from source:
 
 ### From Source
 
-We have included R sources, which can be used to compile R (`R-3.5.1.tar.gz`).
+We have included R sources, which can be used to compile R (`r dir("./extra", pattern = "R-.*.tar.gz")`)
+
 
 To compile and install R from the sources, open a terminal where the `.tar.gz`
 file is located and type the following commands:
 
 ```{r eval = FALSE}
-tar xvfz R-3.5.1.tar.gz
-cd R-3.5.1
+tar xvfz R-.*.tar.gz
+cd R-.*
 ./configure
 make 
 sudo make install

--- a/package_list.txt
+++ b/package_list.txt
@@ -444,6 +444,7 @@ lavaan
 lavaan.survey
 lazyeval
 leaflet
+leaflet.extras
 leaps
 LearnBayes
 learnr

--- a/package_list.txt
+++ b/package_list.txt
@@ -251,6 +251,7 @@ fit.models
 fitdistrplus
 flashClust
 flexclust
+flexdashboard
 flexmix
 flexsurv
 flextable
@@ -768,6 +769,7 @@ rglwidget
 RgoogleMaps
 rhandsontable
 ring
+rio
 riskRegression
 ritis
 RItools

--- a/package_list.txt
+++ b/package_list.txt
@@ -146,9 +146,9 @@ curl
 cyclocomp
 d3heatmap
 DAAG
-datasets
 data.table
 data.tree
+datasets
 date
 DBI
 dbplyr
@@ -247,12 +247,13 @@ fftwtools
 fields
 filehash
 findpython
-fitdistrplus
 fit.models
+fitdistrplus
 flashClust
 flexclust
 flexmix
 flexsurv
+flextable
 FME
 FMStable
 FNN
@@ -272,6 +273,7 @@ fTrading
 fts
 futile.logger
 futile.options
+fuzzyjoin
 GA
 gam
 gamair
@@ -412,6 +414,7 @@ jomo
 jpeg
 jsonlite
 jsonvalidate
+kableExtra
 kappalab
 kernlab
 KernSmooth
@@ -435,9 +438,9 @@ latentnet
 lattice
 latticeExtra
 lava
+lava.tobit
 lavaan
 lavaan.survey
-lava.tobit
 lazyeval
 leaflet
 leaps
@@ -685,6 +688,13 @@ quantmod
 quantreg
 questionr
 qvcalc
+R.cache
+R.devices
+R.matlab
+R.methodsS3
+R.oo
+R.rsp
+R.utils
 R0
 R2admb
 R2Cuba
@@ -705,7 +715,6 @@ rasterVis
 rbenchmark
 rbokeh
 rbounds
-R.cache
 Rcgmin
 rcmdcheck
 Rcmdr
@@ -717,14 +726,13 @@ RcppEigen
 RcppParallel
 Rcsdp
 RCurl
-R.devices
 readbitmap
 readbulk
 readr
 readstata13
 readxl
-recontools
 recon.ui
+recontools
 redux
 REEMtree
 RefManageR
@@ -774,9 +782,7 @@ rlecuyer
 RLumShiny
 rmapshaper
 rmarkdown
-R.matlab
 rmeta
-R.methodsS3
 Rmisc
 Rmpfr
 rms
@@ -790,7 +796,6 @@ robust
 robustbase
 ROCR
 RODBC
-R.oo
 Rook
 rootSolve
 rotl
@@ -808,7 +813,6 @@ RPushbullet
 rrcov
 rredis
 rredlist
-R.rsp
 RSAGA
 rsatscan
 RSclient
@@ -827,7 +831,6 @@ RSVGTipsDevice
 rticles
 Rttf2pt1
 RUnit
-R.utils
 rversions
 rvest
 Rvmmin

--- a/package_sources.txt
+++ b/package_sources.txt
@@ -9,10 +9,16 @@ repo::https://dide-tools.github.io/drat
 # reconhub/incidence
 reconhub/epicontacts@ttree
 reconhub/linelist
-# reconhub/epitrix
+reconhub/epitrix
 # reconhub/earlyR
-# reconhub/projections
+reconhub/projections
 # reconhub/epiflows
+ffinger/followup
+reconhub/epirisk
+reconhub/linelist
+reconhub/aweek
+cttobin/ggthemr
+
 
 # Pakcages currently only on github
 


### PR DESCRIPTION
This PR does the following:

1. Adds `add_packages.R` script to automatically add packages to the package_list.txt file
2. adds flextable, fuzzyjoin, and kableExtra, rio, and leaflet.extras to close #25 and #26
4. adds epitrix, projections, followup, epirisk, linelist, aweek, and ggthemr to the package sources
3. Adds `generate_deployer.R` script, which will generate the deployer, the md5sums, and the markdown file for release.
4. Auto-updates README.md which addresses #24 