### PR TITLE
Znk fix 31

### DIFF
--- a/inst/update_deployer.R
+++ b/inst/update_deployer.R
@@ -18,7 +18,9 @@ update_package <- function(pkg = NULL, repo = ".", internet = FALSE, windows = T
     )
     stop(msg)
   }
-  src <- win <- mac <- elc <- NULL
+  src  <- win <- mac <- elc <- NULL
+  repo <- normalizePath(repo)
+
   stopifnot(file.exists(file.path(repo, 'src', 'contrib')))
   ext <- tools::file_ext(pkg)
   tmp <- tempdir()
@@ -27,7 +29,7 @@ update_package <- function(pkg = NULL, repo = ".", internet = FALSE, windows = T
   if (ext == "" && dir.exists(pkg)) {
     vers <- read.dcf(file.path(pkg, "DESCRIPTION"))[, "Version"]
     message("Building source package ...")
-    pkg <- devtools::build(pkg, path = tmp, binary = FALSE)
+    src <- pkg <- devtools::build(pkg, path = tmp, binary = FALSE)
   } else if (ext == "" && internet) { # The package is one the user wants to download
     message("Downloading the source package from CRAN ...")
     try(src <- download.packages(pkg, type = "source", destdir = tmp)[2])
@@ -47,24 +49,24 @@ update_package <- function(pkg = NULL, repo = ".", internet = FALSE, windows = T
   }
 
   # adding source package ------------------------------------------------------
-  message(sprintf("Adding source package and to %s", repo))
+  message(sprintf("Adding source package to %s", repo))
   drat::insertPackage(src, action = "archive", repodir = repo) 
 
   # adding windows package -----------------------------------------------------
   if (!is.null(win)) {
-    message(sprintf("Adding windows package and to %s", repo))
+    message(sprintf("Adding windows package to %s", repo))
     try(drat::insertPackage(win, action = "archive", repodir = repo))
   }
 
   # adding macos package -----------------------------------------------------
   if (!is.null(mac)) {
-    message(sprintf("Adding macos package and to %s", repo))
+    message(sprintf("Adding macos package to %s", repo))
     try(drat::insertPackage(mac, action = "archive", repodir = repo))
   }
 
   # adding macos.el-capitan package -----------------------------------------------------
   if (!is.null(mac)) {
-    message(sprintf("Adding macos el-capitan package and to %s", repo))
+    message(sprintf("Adding macos el-capitan package to %s", repo))
     try(drat::insertPackage(elc, action = "archive", repodir = repo))
   }
   # ----------------------------------------------------------------------------


### PR DESCRIPTION
This will fix #31 

The problem was that I wasn't updating the `src` variable. I think I was starting the road to burnout when I wrote this because there were a lot of grammatical errors in the comments. 

Below, you can see the function working as expected, building and inserting the reportfactory package from my system and showing that it was built 8 seconds after I had called `Sys.time()`:

```
> Sys.time()                                                                                                                                                                                    
[1] "2019-10-14 10:29:04 BST"
> source('update_deployer.R')                                                                                                                                                                   
> update_package(pkg="~/Documents/Projects/reconhub--reportfactory/")                                                                                                                           
Building source package ...
✔  checking for file ‘/home/zkamvar/Documents/Projects/reconhub--reportfactory/DESCRIPTION’ ...
─  preparing ‘reportfactory’:
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  building ‘reportfactory_0.0.4.tar.gz’
   
Adding source package and to /home/zkamvar/Documents/Projects/deployer_2019_09_11
NULL
> install.packages('reportfactory')                                                                                                                                                             
Installing package into ‘/home/zkamvar/Documents/RLibrary’
(as ‘lib’ is unspecified)
* installing *source* package ‘reportfactory’ ...
** using staged installation
** R
** inst
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (reportfactory)
> packageDescription('reportfactory')                                                                                                                                                           
Package: reportfactory
Type: Package
Title: Report factory
Version: 0.0.4
Authors@R: c(person("Thibaut", "Jombart", role = c("aut", "cre"), email = "thibautjombart@gmail.com"), person("Zhian N.", "Kamvar", role = "ctb", email =
                   "zkamvar@gmail.com"))
Description: Lightweight infrastructure for handling multiple dated reports using \code{rmarkdown::render}.
License: MIT + file LICENSE
URL: https://github.com/reconhub/reportfactory
BugReports: https://github.com/reconhub/reportfactory/issues
RoxygenNote: 6.1.1
Imports: checkpoint, rmarkdown (>= 1.13), rprojroot
Suggests: here, knitr, testthat, dplyr, earlyR, epicontacts, ggplot2, incidence, magrittr, projections, readxl, tidyr
VignetteBuilder: knitr
NeedsCompilation: no
Packaged: 2019-10-14 09:29:12 UTC; zkamvar
Author: Thibaut Jombart [aut, cre], Zhian N. Kamvar [ctb]
Maintainer: Thibaut Jombart <thibautjombart@gmail.com>
Built: R 3.6.1; ; 2019-10-14 09:29:43 UTC; unix

-- File: /home/zkamvar/Documents/RLibrary/reportfactory/Meta/package.rds 
```